### PR TITLE
Bump deps

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,17 +1,13 @@
 {erl_opts, []}.
 
 {deps, [
-    {lfe, {git, "git://github.com/rvirding/lfe", {branch, "develop"}}},
-    {kla, {git, "git://github.com/lfex/kla", {tag, "0.5.0"}}},
-    {rabbit_common, "3.5.6"},
-    {amqp_client, "3.5.6"}
+    lfe,
+    {kla, "0.8.0-rc4"},
+    {amqp_client, {git, "git@github.com:jbrisbin/amqp_client", {branch, "master"}}},
+    {rabbit_common, {git, "git@github.com:jbrisbin/rabbit_common", {branch, "master"}}}
 ]}.
 
-{plugins, [
-    {'lfe-compile', {git, "https://github.com/lfe-rebar3/compile.git", {branch, "master"}}},
-    {'lfe-clean', {git, "https://github.com/lfe-rebar3/clean.git", {branch, "master"}}},
-    {'lfe-repl', {git, "git://github.com/lfe-rebar3/repl.git", {branch, "master"}}}
-]}.
+{plugins, [{'lfe-compile', "0.8.0-rc3", {pkg, rebar3_lfe_compile}}]}.
 
 {provider_hooks, [
   {pre, [{compile, {lfe, compile}}]}

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,5 @@
 {erl_opts, []}.
+{lfe_first_files, []}.
 
 {deps, [
     lfe,
@@ -11,4 +12,19 @@
 
 {provider_hooks, [
   {pre, [{compile, {lfe, compile}}]}
+]}.
+
+{profiles, [
+  {test, [
+    {eunit_compile_opts, [
+      {src_dirs, ["test", "src"]}
+      ]},
+    {deps, [ltest]}
+  ]},
+
+  {doc, [
+    {plugins, [
+      {lodox, {git, "https://github.com/lfe-rebar3/lodox.git", {tag, "0.16.2"}}}
+      ]}
+  ]}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,10 +1,16 @@
-[{<<"amqp_client">>,{pkg,<<"amqp_client">>,<<"3.5.6">>},0},
- {<<"kla">>,
-  {git,"git://github.com/lfex/kla",
-       {ref,"e9ed980aec9c18b67a8b5f9c22cfebc778282d04"}},
+{"1.1.0",
+[{<<"amqp_client">>,
+  {git,"git@github.com:jbrisbin/amqp_client",
+       {ref,"d50aec00b94f0766a048b4eceaf25ddfdeeb1d86"}},
   0},
- {<<"lfe">>,
-  {git,"git://github.com/rvirding/lfe",
-       {ref,"d102f6412992a37e01666cd57bdb5ecd1828b171"}},
-  0},
- {<<"rabbit_common">>,{pkg,<<"rabbit_common">>,<<"3.5.6">>},0}].
+ {<<"kla">>,{pkg,<<"kla">>,<<"0.8.0-rc4">>},0},
+ {<<"lfe">>,{pkg,<<"lfe">>,<<"1.2.0">>},0},
+ {<<"rabbit_common">>,
+  {git,"git@github.com:jbrisbin/rabbit_common",
+       {ref,"80814606ae23cc820c74e443383e192cd69ec030"}},
+  0}]}.
+[
+{pkg_hash,[
+ {<<"kla">>, <<"0E6A7FD64A387E746F081D28C6793200CFC1F01126E36C975A6A91E8858E1C4B">>},
+ {<<"lfe">>, <<"257708859C0A6949F174CECEE6F08BB5D6F08C0F97EC7B75C07072014723ECBC">>}]}
+].


### PR DESCRIPTION
This PR bumps all the dependencies.

Note that I'm not using the hex published RabbitMQ libraries as they do not compile on Erlang 19. If desirable I can lock the dependencies to the ones in hex instead.